### PR TITLE
Update newsletterr.py to fix filtering for blank email users sent to Conjurr

### DIFF
--- a/newsletterr.py
+++ b/newsletterr.py
@@ -5506,7 +5506,11 @@ def pull_recommendations():
             "conjurr_url": ""
         }
 
-    filtered_users = {k: v for k, v in user_dict.items() if v in to_emails}
+    selected_emails = {e.strip().lower() for e in to_emails.split(',') if e.strip()}
+    filtered_users = {
+    k: v for k, v in user_dict.items()
+    if v and str(v).strip().lower() in selected_emails
+    }
 
     if request.method == 'POST':
         if conjurr_settings['conjurr_url'] == "":


### PR DESCRIPTION
Changed the Get Recommendation user filtering to use exact case-insensitive email matching and ignore blank email values.

The previous logic used a substring check against the joined BCC email string, which meant users with blank email addresses could be included because `"" in "user@example.com"` returns `True`.

I tested this locally with Conjurr enabled. Before the change, selecting a single BCC recipient caused recommendations to be pulled for that user plus extra Plex/Tautulli users with blank email values (Plex 'Home' users). After the change, Conjurr was only called for the selected BCC user.