### PR TITLE
Update newsletterr.py to fix filtering for blank email users

### DIFF
--- a/newsletterr.py
+++ b/newsletterr.py
@@ -5506,7 +5506,11 @@ def pull_recommendations():
             "conjurr_url": ""
         }
 
-    filtered_users = {k: v for k, v in user_dict.items() if v in to_emails}
+    selected_emails = {e.strip().lower() for e in to_emails.split(',') if e.strip()}
+    filtered_users = {
+    k: v for k, v in user_dict.items()
+    if v and str(v).strip().lower() in selected_emails
+    }
 
     if request.method == 'POST':
         if conjurr_settings['conjurr_url'] == "":


### PR DESCRIPTION
Opening PR to nightly instead as requested

Use exact case-insensitive email matching when filtering recommendation users, and ignore blank email values - I was constantly seeing recommendations being sent to Conjurr for my 'Plex Home' users (children), even if I had only a single plex user email address in the BCC list, that wasn't even part of my Plex home group.