### PR TITLE
Update stats.py to fix e-mail filtering

### DIFF
--- a/app/blueprints/stats.py
+++ b/app/blueprints/stats.py
@@ -166,7 +166,11 @@ def pull_recommendations():
             "conjurr_url": ""
         }
 
-    filtered_users = {k: v for k, v in user_dict.items() if v in to_emails}
+    selected_emails = {e.strip().lower() for e in to_emails.split(',') if e.strip()}
+    filtered_users = {
+    k: v for k, v in user_dict.items()
+    if v and str(v).strip().lower() in selected_emails
+    }
 
     if request.method == 'POST':
         if conjurr_settings['conjurr_url'] == "":


### PR DESCRIPTION
As requested - recreated the change against `nightly` and updated the code in it's new location in stats.py

"This uses exact case-insensitive email matching when filtering recommendation users and ignores blank email values. Previously, I was seeing recommendations being sent to Conjurr for Plex Home users with blank email addresses even when only a single unrelated Plex user email was present in the BCC list."