### PR TITLE
fix: use exact match for library filter to prevent wrong library content

### DIFF
--- a/app/emails/builders/recently_added.py
+++ b/app/emails/builders/recently_added.py
@@ -24,7 +24,7 @@ def build_recently_added_html_with_cids(recent_data, msg_root, theme_colors, lib
                 items.append(item)
     
     if library_filter:
-        items = [item for item in items if library_filter.lower() in item.get('library_name', '').lower()]
+        items = [item for item in items if library_filter.lower() == item.get('library_name', '').lower()]
 
     if recently_added_mode != "days" and max_items and len(items) > max_items:
         items = items[:max_items]

--- a/templates/schedule_preview.html
+++ b/templates/schedule_preview.html
@@ -1046,7 +1046,7 @@
         
         if (libraryFilter) {
             allItems = allItems.filter(item => 
-                item.library_name && item.library_name.toLowerCase().includes(libraryFilter.toLowerCase())
+                item.library_name && item.library_name.toLowerCase() === libraryFilter.toLowerCase()
             );
         }
         


### PR DESCRIPTION
## Problem
Recently Added snap-ins pull content from the wrong library when one library name is a substring of another. For example a "Movies" snap-in pulls from "Christian Movies" instead of "Movies" because the filter uses substring matching.

## Changes
- `app/emails/builders/recently_added.py` line 27: changed `in` to `==`
- `templates/schedule_preview.html` line 1049: changed `.includes()` to `===`

## Testing
Verified fix on a live instance with the following libraries:
- Movies / Christian Movies / Christmas Movies / Kids Movies
- TV Shows / Documentary TV Shows / Kids TV Shows
- Concerts and Comedy / Music

All snap-ins now correctly pull from their designated library only.

Fixes #103 